### PR TITLE
Support more FsCheck features within Computation Expressions

### DIFF
--- a/src/Aenea.Cli/Program.fs
+++ b/src/Aenea.Cli/Program.fs
@@ -44,6 +44,7 @@ let main argv =
                 fun (xs:list<int>) ->
                    List.rev(List.rev xs) = xs
             }
+
             testGroup "My other group" {
                 max_test 12
 
@@ -67,6 +68,19 @@ let main argv =
                     List.rev(List.rev xs) = xs
             }
 
+            testGroup "FsCheck Properties" {
+                test "imply" {
+                    fun (x:int) ->
+                       (x % 2 = 0) ==> lazy ((x * 2) % 2 = 0)
+                }
+                test "labels" {
+                    pending // uncomment to see failures with printed labels
+                    fun (x:int) ->
+                        (x % 2 = 0) |@ "not even"
+                        .&.
+                        (sign x = 1) |@ "not positive"
+                }
+            }
         }
     run group
 

--- a/src/Aenea/Library.fs
+++ b/src/Aenea/Library.fs
@@ -127,7 +127,7 @@ module CeDSL =
     type TestCaseState<'a> = {
         Name: string
         State: State
-        TestCode: ('a -> bool) option
+        TestCode: Property option
         IsExample: bool
         WithConfig: (Config -> Config) option
     }
@@ -176,8 +176,12 @@ module CeDSL =
         member __.Yield(other: unit) =
             state
 
+        member __.Yield(code: 'a -> Property) =
+            state <- {state with TestCode = Some (Prop.ofTestable code)}
+            state
+
         member __.Yield(code: 'a -> bool) =
-            state <- {state with TestCode = Some code}
+            state <- {state with TestCode = Some (Prop.ofTestable code)}
             state
 
         member __.Delay f = f()
@@ -269,5 +273,3 @@ module CeDSL =
             TestGroup(state.Name, List.rev state.Tests, state.WithConfig, state.State)
 
     let testGroup name = TestGroupBuilder name
-
-


### PR DESCRIPTION
This PR enables the use of several more FsCheck features:

- compound properties
- property lables
- implications
- observations

It might also enable more things (but the above are the ones I use frequently/tested). Further, this PR only impacts the CE DSL, as the list DSL already seems to support these features. 

I'm not sure if this changes is sufficiently robust (but it's a start)...

- Changes one the data type of one of the fields on the internal state of the CE builder
- Adjusts one overload of `Yield` to support the data type change
- Adds a new overload of `Yield` which accepts functions which return `Property`
- Adds some demonstrative samples to `Aenea.Cli` project